### PR TITLE
Use single-quotes for strings

### DIFF
--- a/sql.md
+++ b/sql.md
@@ -181,7 +181,7 @@ criteria.  For example, let’s say we only want data for the species _Dipodomys
 merriami_, which has a species code of DM.  We need to add a WHERE clause to our
 query:
 
-    SELECT * FROM surveys WHERE species_id="DM";
+    SELECT * FROM surveys WHERE species_id='DM';
 
 We can do the same thing with numbers.
 Here, we only want the data since 2000:
@@ -192,7 +192,7 @@ We can use more sophisticated conditions by combining tests with AND and OR.
 For example, suppose we want the data on _Dipodomys merriami_ starting in the year
 2000:
 
-    SELECT * FROM surveys WHERE (year >= 2000) AND (species_id = "DM");
+    SELECT * FROM surveys WHERE (year >= 2000) AND (species_id = 'DM');
 
 Note that the parentheses aren’t needed, but again, they help with readability.
 They also ensure that the computer combines AND and OR in the way that we
@@ -201,7 +201,7 @@ intend.
 If we wanted to get data for any of the _Dipodomys_ species,
 which have species codes DM, DO, and DS we could combine the tests using OR:
 
-    SELECT * FROM surveys WHERE (species_id = "DM") OR (species_id = "DO") OR (species_id = "DS");
+    SELECT * FROM surveys WHERE (species_id = 'DM') OR (species_id = 'DO') OR (species_id = 'DS');
 
 > ### Challenge
 >
@@ -224,11 +224,11 @@ the year 2000 on.  This time, let’s use IN as one way to make the query easier
 to understand.  It is equivalent to saying `WHERE (species_id = "DM") OR (species_id
 = "DO") OR (species_id = "DS")`, but reads more neatly:
 
-    SELECT * FROM surveys WHERE (year >= 2000) AND (species_id IN ("DM", "DO", "DS"));
+    SELECT * FROM surveys WHERE (year >= 2000) AND (species_id IN ('DM', 'DO', 'DS'));
 
     SELECT *
     FROM surveys
-    WHERE (year >= 2000) AND (species_id IN ("DM", "DO", "DS"));
+    WHERE (year >= 2000) AND (species_id IN ('DM', 'DO', 'DS'));
 
 We started with something simple, then added more clauses one by one, testing
 their effects as we went along.  For complex queries, this is a good strategy,
@@ -270,7 +270,7 @@ Another note for ordering. We don’t actually have to display a column to sort 
 it.  For example, let’s say we want to order the birds by their species ID, but
 we only want to see genus and species.
 
-    SELECT genus, species FROM species WHERE taxa = "Bird" ORDER BY species_id ASC;
+    SELECT genus, species FROM species WHERE taxa = 'Bird' ORDER BY species_id ASC;
 
 We can do this because sorting occurs earlier in the computational pipeline than
 field selection.


### PR DESCRIPTION
The SQL standard requires single-quotes (apostrophes) for strings;
double-quoted strings denote quoted identifiers which are matched case
sensitively on most engines.

Double quoted strings work on *some* engines (specifically SQLite and
MySQL with its default settings - possibly Access although I'm not
familiar with it) but on most other engines (DB2, Oracle, Firebird,
later versions of PostgreSQL, etc.) they will fail. Single quoted
strings work universally, so this won't break any existing lessons but
may save learners some headaches in future!