### PR TITLE
Use single quotes for strings

### DIFF
--- a/01-sql-basic-queries.md
+++ b/01-sql-basic-queries.md
@@ -67,7 +67,7 @@ criteria.  For example, let’s say we only want data for the species _Dipodomys
 merriami_, which has a species code of DM.  We need to add a WHERE clause to our
 query:
 
-    SELECT * FROM surveys WHERE species_id="DM";
+    SELECT * FROM surveys WHERE species_id='DM';
 
 We can do the same thing with numbers.
 Here, we only want the data since 2000:
@@ -78,7 +78,7 @@ We can use more sophisticated conditions by combining tests with AND and OR.
 For example, suppose we want the data on _Dipodomys merriami_ starting in the year
 2000:
 
-    SELECT * FROM surveys WHERE (year >= 2000) AND (species_id = "DM");
+    SELECT * FROM surveys WHERE (year >= 2000) AND (species_id = 'DM');
 
 Note that the parentheses aren’t needed, but again, they help with readability.
 They also ensure that the computer combines AND and OR in the way that we
@@ -87,7 +87,7 @@ intend.
 If we wanted to get data for any of the _Dipodomys_ species,
 which have species codes DM, DO, and DS we could combine the tests using OR:
 
-    SELECT * FROM surveys WHERE (species_id = "DM") OR (species_id = "DO") OR (species_id = "DS");
+    SELECT * FROM surveys WHERE (species_id = 'DM') OR (species_id = 'DO') OR (species_id = 'DS');
 
 > ### Challenge
 >
@@ -115,14 +115,14 @@ Building more complex queries
 
 Now, lets combine the above queries to get data for the 3 _Dipodomys_ species from
 the year 2000 on.  This time, let’s use IN as one way to make the query easier
-to understand.  It is equivalent to saying `WHERE (species_id = "DM") OR (species_id
-= "DO") OR (species_id = "DS")`, but reads more neatly:
+to understand.  It is equivalent to saying `WHERE (species_id = 'DM') OR (species_id
+= 'DO') OR (species_id = 'DS')`, but reads more neatly:
 
-    SELECT * FROM surveys WHERE (year >= 2000) AND (species_id IN ("DM", "DO", "DS"));
+    SELECT * FROM surveys WHERE (year >= 2000) AND (species_id IN ('DM', 'DO', 'DS'));
 
     SELECT *
     FROM surveys
-    WHERE (year >= 2000) AND (species_id IN ("DM", "DO", "DS"));
+    WHERE (year >= 2000) AND (species_id IN ('DM', 'DO', 'DS'));
 
 We started with something simple, then added more clauses one by one, testing
 their effects as we went along.  For complex queries, this is a good strategy,
@@ -164,7 +164,7 @@ Another note for ordering. We don’t actually have to display a column to sort 
 it.  For example, let’s say we want to order the birds by their species ID, but
 we only want to see genus and species.
 
-    SELECT genus, species FROM species WHERE taxa = "Bird" ORDER BY species_id ASC;
+    SELECT genus, species FROM species WHERE taxa = 'Bird' ORDER BY species_id ASC;
 
 We can do this because sorting occurs earlier in the computational pipeline than
 field selection.

--- a/sql-solutions.md
+++ b/sql-solutions.md
@@ -21,7 +21,7 @@ Write a query that returns the year, month, day, species and weight in mg
 
 	SELECT year, month, day, species, wgt/100 
 	FROM surveys 
-	WHERE (plot ="1") AND (wgt > "75")
+	WHERE (plot = 1) AND (wgt >  75)
 
 
 **EXERCISE**  
@@ -31,7 +31,7 @@ Write a query that returns the year, month, day, species and weight in mg
  	SELECT surveys.month, surveys.day, surveys.year, surveys.wgt/1000.0, species.species_id 
  	FROM surveys  
  	JOIN species ON surveys.species = species.species_id 
- 	WHERE (surveys.wgt >"75") AND (surveys.plot ="1")
+ 	WHERE (surveys.wgt > 75) AND (surveys.plot = 1)
  
 **EXERCISE**   
 Write a query that returns day, month, year, species for individuals caught  in January, May and July  
@@ -39,7 +39,7 @@ Write a query that returns day, month, year, species for individuals caught  in 
 
 	SELECT year, month, day, species, wgt/100 
 	FROM surveys 
-	WHERE (month IN ("1", "5", "7"));
+	WHERE (month IN (1, 5, 7));
  
 
 
@@ -56,7 +56,7 @@ Write a query that returns day, month, year, species for individuals caught  in 
  
 	 SELECT year, month, day, species, ROUND(wgt/100,2) 
 	 FROM surveys 
-	 WHERE  (year="1999") 
+	 WHERE (year=1999) 
 	 ORDER BY species ASC
  
  


### PR DESCRIPTION
Re-applying changes for strings now the lessons have been split into
separate files. Also fixed a few cases in the sql-solutions page where
numbers were quoted as strings but obviously being treated as numbers
(for example, weight > "75").