### PR TITLE
Tidy up SQL solutions

### DIFF
--- a/sql-solutions.md
+++ b/sql-solutions.md
@@ -4,117 +4,148 @@ root: .
 title: Solutions to SQL exercises
 ---
 
-#####WARNING
-This file may not be always up to date with regards to the exact exercises instructions and the naming of the columns and tables in the database. Check before you run the workshop!
+##### WARNING
+
+This file may not be always up to date with regards to the exact exercises
+instructions and the naming of the columns and tables in the database. Check
+before you run the workshop!
 
 
-**EXERCISE**  
-Write a query that returns the year, month, day, species and weight in mg  
-**SOLUTION**  
+**EXERCISE**
 
-	SELECT year, month, day, species, wgt*1000 FROM surveys
+Write a query that returns the year, month, day, species ID and weight (in mg).
 
-
-**EXERCISE**  
- Write a query that returns the day, month, year, species, and weight (in kg) for individuals caught on Plot 1 that weigh more than 75 g  
-**SOLUTION**  
-
-	SELECT year, month, day, species, wgt/100 
-	FROM surveys 
-	WHERE (plot = 1) AND (wgt >  75)
-
-
-**EXERCISE**  
- Write a query that returns The day, month, year, species ID, and weight (in kg) for individuals caught on Plot 1 that weigh more than 75 g  
 **SOLUTION**
- 
- 	SELECT surveys.month, surveys.day, surveys.year, surveys.wgt/1000.0, species.species_id 
- 	FROM surveys  
- 	JOIN species ON surveys.species = species.species_id 
- 	WHERE (surveys.wgt > 75) AND (surveys.plot = 1)
- 
-**EXERCISE**   
-Write a query that returns day, month, year, species for individuals caught  in January, May and July  
- **SOLUTION**  
 
-	SELECT year, month, day, species, wgt/100 
-	FROM surveys 
-	WHERE (month IN (1, 5, 7));
- 
+	SELECT day, month, year, species_id, weight * 1000
+	FROM surveys;
 
 
-**EXERCISE**   
- Write a query that returns year, species, and weight in kg from the surveys table, sorted with the largest weights at the top  
-**SOLUTION**  
+**EXERCISE**
 
-	SELECT year, month, day, species, wgt/100 
-	FROM surveys ORDER BY wgt DESC
+Write a query that returns the day, month, year, species ID, and weight (in kg)
+for individuals caught on Plot 1 that weigh more than 75 g.
 
-**EXERCISE**    
- Let’s try to combine what we’ve learned so far in a single query. Using the surveys table write a query to display the three date fields, species ID, and weight in kilograms (rounded to two decimal places), for rodents captured in 1999, ordered alphabetically by the species ID.
+**SOLUTION**
+
+	SELECT day, month, year, species_id, weight / 1000.0
+	FROM surveys
+	WHERE plot_id = 1
+	AND weight > 75;
+
+
+**EXERCISE**
+
+Write a query that returns the day, month, year, species ID, and weight (in kg)
+for individuals caught on Plot 1 that weigh more than 75 g.
+
+**SOLUTION**
+
+	SELECT
+		surveys.day,
+		surveys.month,
+		surveys.year,
+		species.species_id,
+		surveys.weight / 1000.0
+	FROM surveys
+	JOIN species ON surveys.species_id = species.species_id
+	WHERE surveys.weight > 75
+	AND surveys.plot_id = 1;
+
+
+**EXERCISE**
+
+Write a query that returns day, month, year, species ID for individuals caught
+in January, May and July.
+
  **SOLUTION**
- 
-	 SELECT year, month, day, species, ROUND(wgt/100,2) 
-	 FROM surveys 
-	 WHERE (year=1999) 
-	 ORDER BY species ASC
- 
- 
 
-**EXERCISE**    
-Write queries that return: 1. How many individuals were counted in each year 2. Average weight of each species in each year  
-**SOLUTION**  
+	SELECT day, month, year, species_id
+	FROM surveys
+	WHERE month IN (1, 5, 7);
 
-	
+
+**EXERCISE**
+
+Write a query that returns year, species ID, and weight in kg from the surveys
+table, sorted with the largest weights at the top.
+
+**SOLUTION**
+
+	SELECT year, species_id, weight / 1000.0
+	FROM surveys ORDER BY weight DESC;
+
+
+**EXERCISE**
+
+Let’s try to combine what we’ve learned so far in a single query. Using the
+surveys table write a query to display the three date fields, species ID, and
+weight in kilograms (rounded to two decimal places), for rodents captured in
+1999, ordered alphabetically by the species ID.
+
+**SOLUTION**
+
+	SELECT year, month, day, species_id, ROUND(weight / 1000.0, 2)
+	FROM surveys
+	WHERE year = 1999
+	ORDER BY species_id;
+
+
+**EXERCISE**
+
+Write queries that return:
+
+1. How many individuals were counted in each year.
+
+2. Average weight of each species in each year.
+
+**SOLUTION**
+
 	SELECT year, COUNT(*)
 	FROM surveys
 	GROUP BY year;
-	
-	SELECT year, species, COUNT(*)
+
+	SELECT year, species_id, ROUND(AVG(weight), 2)
 	FROM surveys
-	GROUP BY year
-	ORDER BY COUNT(species)
-	
-		
-	SELECT year, species, SUM(wgt)
-	FROM surveys
-	GROUP BY year, species
-	ORDER BY year
-	
-	
-	SELECT year, species, ROUND(AVG(wgt), 2)
-	FROM surveys
-	GROUP BY year, species;
-	
-	
+	GROUP BY year, species_id;
+
+
 **EXERCISE**
-Write a query that returns the number of each species caught in each year sorted from most often caught species to the least occurring ones within each year starting from the most recent records.
 
-**SOLUTION**   
-    
-    SELECT year, species_id, COUNT(*) FROM surveys
-    GROUP BY species_id, year  
-    ORDER BY(year) DESC, COUNT(*) DESC	
-	
-	
+Write a query that returns the number of each species caught in each year
+sorted from most often caught species to the least occurring ones within each
+year starting from the most recent records.
 
-**EXERCISE**  
- Write a query that returns the genus, the species, and the weight of every individual captured at the site  
-**SOLUTION**  
+**SOLUTION**
 
-	SELECT species.genus, species.species_id, surveys.wgt 
-	FROM surveys 
-	JOIN species 
-	ON surveys.species = species.species_id 
-	
-	
-**EXERCISE** 	
-Write a query that returns the number of genus of the animals caught in each plot in descending order.
+	SELECT year, species_id, COUNT(*)
+	FROM surveys
+	GROUP BY year, species_id
+	ORDER BY year DESC, COUNT(*) DESC;
 
-**SOLUTION** 
 
-    SELECT surveys.plot, species.genus, COUNT(*)
-    FROM surveys
-    JOIN species ON surveys.species_id = species.species_id
-    GROUP BY (species.genus), surveys.plot
-    ORDER BY surveys.plot, (COUNT(*)) DESC
+**EXERCISE**
+
+Write a query that returns the genus, the species, and the weight of every
+individual captured at the site.
+
+**SOLUTION**
+
+	SELECT species.genus, species.species_id, surveys.weight
+	FROM surveys
+	JOIN species ON surveys.species_id = species.species_id;
+
+
+**EXERCISE**
+
+Write a query that returns the number of genus of the animals caught in each
+plot in descending order.
+
+**SOLUTION**
+
+	SELECT surveys.plot_id, species.genus, COUNT(*)
+	FROM surveys
+	JOIN species ON surveys.species_id = species.species_id
+	GROUP BY species.genus, surveys.plot_id
+	ORDER BY surveys.plot_id, COUNT(*) DESC
+


### PR DESCRIPTION
Fairly major tidy up of SQL solutions: removed all trailing whitespace,
wrapped everything at 80 columns and made all indentation consistent (as
per CONTRIBUTING.md). Also fixed several errors in the queries: many
referred to columns like "species", "plot" and "wgt", but these are
"species_id", "plot_id", and "weight" in database. Some queries
intending to convert g to kg divided by 100 instead of 1000, and there
were plenty of extraneous brackets to remove.